### PR TITLE
Modificacion tabla de tiempos y descarga de reporte

### DIFF
--- a/STUART-Frontend/src/script_results.js
+++ b/STUART-Frontend/src/script_results.js
@@ -258,7 +258,7 @@ function buildCuriosityTable(times, part) {
     rows += `
       <tr>
         <td>${videoName}</td>
-        <td>${part}</td>
+        <td>Nariz</td>
         <td>${entry.object}</td>
         <td>${entry.time.toFixed(2)} seg</td>
       </tr>
@@ -384,7 +384,7 @@ async function downloadPDF() {
       if (data.times && data.times.length > 0) {
         bodyRows = data.times.map((entry) => [
           videoName,
-          part,
+          'Nariz',
           entry.object,
           `${entry.time.toFixed(2)} segundos`,
         ]);


### PR DESCRIPTION
La columna keypoint debe permanecer siempre igual, con el valor "Nariz" ya que es el keypoint en base al cual se calcula el tiempo de interés, las demás partes del ratón no poseen interés hacia el objeto.